### PR TITLE
Add translation support to package

### DIFF
--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'title' => 'Settings',
+    'page_title' => 'Manage Settings',
+    'save_button' => 'Save Settings',
+    'success_message' => 'Settings have been saved successfully.',
+    'fields' => [
+        'key' => 'Key',
+        'value' => 'Value',
+        'type' => 'Type',
+        'description' => 'Description',
+    ],
+];

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -32,9 +32,14 @@ class SettingsServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/views/' => resource_path('views/vendor/filament-settings'),
             ], 'filament-settings-views');
+
+            $this->publishes([
+                __DIR__.'/../resources/lang' => $this->app->langPath('vendor/filament-settings'),
+            ], 'filament-settings-translations');
         }
 
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'filament-settings');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'filament-settings');
     }
 }


### PR DESCRIPTION
## Summary
- Added `loadTranslationsFrom()` method to load package translations from `resources/lang` directory
- Added publishable translations tag to allow users to publish translations via `vendor:publish`
- Created initial English translation file with common setting-related keys

## Implementation Details
- Translation namespace: `filament-settings`
- Translations can be published using: `php artisan vendor:publish --tag=filament-settings-translations`
- Usage in views/code: `__('filament-settings::settings.title')`

## Test plan
- [ ] Verify translations load correctly in the package
- [ ] Test publishing translations with `vendor:publish` command
- [ ] Confirm translation keys work in Blade views and PHP code

🤖 Generated with [Claude Code](https://claude.ai/code)