### PR TITLE
Refactor field types with enum structure and separate blade files

### DIFF
--- a/resources/views/fields/boolean.blade.php
+++ b/resources/views/fields/boolean.blade.php
@@ -1,0 +1,11 @@
+<label class="flex items-center space-x-3">
+    <input type="checkbox" 
+        wire:model="data.{{ $key }}"
+        class="rounded border-gray-300 text-primary-600 focus:ring-primary-600 @error('data.' . $key) border-danger-600 @enderror"
+    />
+    <span>{{ $label }}</span>
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/fields/checkbox.blade.php
+++ b/resources/views/fields/checkbox.blade.php
@@ -1,0 +1,19 @@
+<label class="block text-sm font-medium mb-2">
+    {{ $label }}
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+<div class="space-y-2">
+    @foreach($setting['options'] ?? [] as $optionKey => $optionLabel)
+        <label class="flex items-center space-x-3">
+            <input type="checkbox" 
+                wire:model="data.{{ $key }}" 
+                value="{{ $optionKey }}"
+                class="rounded border-gray-300 text-primary-600 focus:ring-primary-600 @error('data.' . $key) border-danger-600 @enderror"
+            />
+            <span>{{ __($optionLabel) }}</span>
+        </label>
+    @endforeach
+</div>
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/fields/encrypted.blade.php
+++ b/resources/views/fields/encrypted.blade.php
@@ -1,0 +1,13 @@
+<label class="block text-sm font-medium mb-2">
+    {{ $label }}
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+<input 
+    type="password"
+    wire:model="data.{{ $key }}"
+    @if($placeholder) placeholder="{{ $placeholder }}" @endif
+    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
+/>
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/fields/select.blade.php
+++ b/resources/views/fields/select.blade.php
@@ -1,0 +1,13 @@
+<label class="block text-sm font-medium mb-2">
+    {{ $label }}
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+<select wire:model="data.{{ $key }}" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror">
+    <option value="">{{ __('filament-settings::settings.select') ?? 'Select...' }}</option>
+    @foreach($setting['options'] ?? [] as $optionKey => $optionLabel)
+        <option value="{{ $optionKey }}">{{ __($optionLabel) }}</option>
+    @endforeach
+</select>
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/fields/text.blade.php
+++ b/resources/views/fields/text.blade.php
@@ -1,0 +1,33 @@
+@php
+    $inputType = 'text';
+    $step = null;
+    
+    if ($type === 'email') {
+        $inputType = 'email';
+    } elseif ($type === 'url') {
+        $inputType = 'url';
+    } elseif ($type === 'integer' || $type === 'float') {
+        $inputType = 'number';
+        if ($type === 'float') {
+            $step = '0.01';
+        }
+    }
+@endphp
+
+<label class="block text-sm font-medium mb-2">
+    {{ $label }}
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+<input 
+    wire:model="data.{{ $key }}"
+    type="{{ $inputType }}"
+    @if($step) step="{{ $step }}" @endif
+    @if($placeholder) placeholder="{{ $placeholder }}" @endif
+    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
+/>
+@if($helper)
+    <p class="text-sm text-gray-600 mt-1">{{ $helper }}</p>
+@endif
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/fields/textarea.blade.php
+++ b/resources/views/fields/textarea.blade.php
@@ -1,0 +1,13 @@
+<label class="block text-sm font-medium mb-2">
+    {{ $label }}
+    @if($required) <span class="text-danger-600">*</span> @endif
+</label>
+<textarea 
+    wire:model="data.{{ $key }}"
+    rows="3"
+    @if($placeholder) placeholder="{{ $placeholder }}" @endif
+    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
+></textarea>
+@error('data.' . $key)
+    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/partials/setting-field.blade.php
+++ b/resources/views/partials/setting-field.blade.php
@@ -41,6 +41,28 @@
                 @enderror
                 @break
 
+            @case('checkbox')
+                <label class="block text-sm font-medium mb-2">
+                    {{ $label }}
+                    @if($required) <span class="text-danger-600">*</span> @endif
+                </label>
+                <div class="space-y-2">
+                    @foreach($setting['options'] ?? [] as $optionKey => $optionLabel)
+                        <label class="flex items-center space-x-3">
+                            <input type="checkbox" 
+                                wire:model="data.{{ $key }}" 
+                                value="{{ $optionKey }}"
+                                class="rounded border-gray-300 text-primary-600 focus:ring-primary-600 @error('data.' . $key) border-danger-600 @enderror"
+                            />
+                            <span>{{ __($optionLabel) }}</span>
+                        </label>
+                    @endforeach
+                </div>
+                @error('data.' . $key)
+                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
+                @enderror
+                @break
+
             @case('textarea')
                 <label class="block text-sm font-medium mb-2">
                     {{ $label }}

--- a/resources/views/partials/setting-field.blade.php
+++ b/resources/views/partials/setting-field.blade.php
@@ -1,4 +1,6 @@
 @php
+    use Ameax\FilamentSettings\Enums\FieldType;
+    
     $type = $setting['type'] ?? 'string';
     $originalKey = $setting['original_key'] ?? $key;
     $label = isset($setting['label']) ? __($setting['label']) : Str::title(str_replace(['_', '.'], ' ', $originalKey));
@@ -6,115 +8,22 @@
     $required = isset($setting['validation']) && str_contains($setting['validation'], 'required');
     $placeholder = isset($setting['placeholder']) ? __($setting['placeholder']) : null;
     $helper = isset($setting['helper']) ? __($setting['helper']) : null;
+    
+    $fieldType = FieldType::tryFrom($type) ?? FieldType::TEXT;
+    $viewPath = $fieldType->getViewPath();
 @endphp
 
 @if(!($setting['hidden'] ?? false))
     <div>
-        @switch($type)
-            @case('boolean')
-                <label class="flex items-center space-x-3">
-                    <input type="checkbox" 
-                        wire:model="data.{{ $key }}"
-                        class="rounded border-gray-300 text-primary-600 focus:ring-primary-600 @error('data.' . $key) border-danger-600 @enderror"
-                    />
-                    <span>{{ $label }}</span>
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-                @break
-
-            @case('select')
-                <label class="block text-sm font-medium mb-2">
-                    {{ $label }}
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                <select wire:model="data.{{ $key }}" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror">
-                    <option value="">{{ __('filament-settings::settings.select') ?? 'Select...' }}</option>
-                    @foreach($setting['options'] ?? [] as $optionKey => $optionLabel)
-                        <option value="{{ $optionKey }}">{{ __($optionLabel) }}</option>
-                    @endforeach
-                </select>
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-                @break
-
-            @case('checkbox')
-                <label class="block text-sm font-medium mb-2">
-                    {{ $label }}
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                <div class="space-y-2">
-                    @foreach($setting['options'] ?? [] as $optionKey => $optionLabel)
-                        <label class="flex items-center space-x-3">
-                            <input type="checkbox" 
-                                wire:model="data.{{ $key }}" 
-                                value="{{ $optionKey }}"
-                                class="rounded border-gray-300 text-primary-600 focus:ring-primary-600 @error('data.' . $key) border-danger-600 @enderror"
-                            />
-                            <span>{{ __($optionLabel) }}</span>
-                        </label>
-                    @endforeach
-                </div>
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-                @break
-
-            @case('textarea')
-                <label class="block text-sm font-medium mb-2">
-                    {{ $label }}
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                <textarea 
-                    wire:model="data.{{ $key }}"
-                    rows="3"
-                    @if($placeholder) placeholder="{{ $placeholder }}" @endif
-                    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
-                ></textarea>
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-                @break
-
-            @case('encrypted')
-                <label class="block text-sm font-medium mb-2">
-                    {{ $label }}
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                <input 
-                    type="password"
-                    wire:model="data.{{ $key }}"
-                    @if($placeholder) placeholder="{{ $placeholder }}" @endif
-                    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
-                />
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-                @break
-
-            @default
-                <label class="block text-sm font-medium mb-2">
-                    {{ $label }}
-                    @if($required) <span class="text-danger-600">*</span> @endif
-                </label>
-                <input 
-                    wire:model="data.{{ $key }}"
-                    @if($type === 'email') type="email" @endif
-                    @if($type === 'url') type="url" @endif
-                    @if($type === 'integer' || $type === 'float') type="number" @endif
-                    @if($type === 'float') step="0.01" @endif
-                    @if($placeholder) placeholder="{{ $placeholder }}" @endif
-                    class="w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 @error('data.' . $key) border-danger-600 @enderror"
-                />
-                @if($helper)
-                    <p class="text-sm text-gray-600 mt-1">{{ $helper }}</p>
-                @endif
-                @error('data.' . $key)
-                    <p class="text-sm text-danger-600 mt-1">{{ $message }}</p>
-                @enderror
-        @endswitch
+        @include($viewPath, [
+            'key' => $key,
+            'type' => $type,
+            'setting' => $setting,
+            'label' => $label,
+            'value' => $value,
+            'required' => $required,
+            'placeholder' => $placeholder,
+            'helper' => $helper
+        ])
     </div>
 @endif

--- a/src/Enums/FieldType.php
+++ b/src/Enums/FieldType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Ameax\FilamentSettings\Enums;
+
+enum FieldType: string
+{
+    case BOOLEAN = 'boolean';
+    case SELECT = 'select';
+    case CHECKBOX = 'checkbox';
+    case TEXTAREA = 'textarea';
+    case ENCRYPTED = 'encrypted';
+    case TEXT = 'text';
+    case STRING = 'string';
+    case EMAIL = 'email';
+    case URL = 'url';
+    case INTEGER = 'integer';
+    case FLOAT = 'float';
+
+    public function getViewPath(): string
+    {
+        return match($this) {
+            self::BOOLEAN => 'filament-settings::fields.boolean',
+            self::SELECT => 'filament-settings::fields.select',
+            self::CHECKBOX => 'filament-settings::fields.checkbox',
+            self::TEXTAREA => 'filament-settings::fields.textarea',
+            self::ENCRYPTED => 'filament-settings::fields.encrypted',
+            self::TEXT, self::STRING, self::EMAIL, self::URL, self::INTEGER, self::FLOAT => 'filament-settings::fields.text',
+        };
+    }
+
+    public function getInputType(): string
+    {
+        return match($this) {
+            self::EMAIL => 'email',
+            self::URL => 'url',
+            self::INTEGER, self::FLOAT => 'number',
+            default => 'text',
+        };
+    }
+
+    public function getStep(): ?string
+    {
+        return match($this) {
+            self::FLOAT => '0.01',
+            default => null,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add new checkbox field type for handling array data with multiple selections
- Refactor field architecture to use enum-based structure with individual blade files
- Improve code maintainability and extensibility

## Changes Made
- **New Feature**: Added `checkbox` field type that handles array data
- **Refactoring**: Created `FieldType` enum with helper methods for view paths and input types
- **Architecture**: Separated each field type into individual blade files in `resources/views/fields/`
- **Maintainability**: Updated main `setting-field.blade.php` to use includes with enum-based view resolution

## File Structure
```
src/Enums/FieldType.php                    # New enum for field types
resources/views/fields/
├── boolean.blade.php                      # Boolean checkbox field
├── checkbox.blade.php                     # Multi-select checkbox field (NEW)
├── encrypted.blade.php                    # Password field
├── select.blade.php                       # Single select dropdown
├── text.blade.php                         # Text input variants
└── textarea.blade.php                     # Textarea field
```

## Benefits
- **Extensibility**: Adding new field types only requires adding to enum and creating a blade file
- **Maintainability**: Each field type is isolated in its own template
- **Type Safety**: Enum provides compile-time checks for field types
- **Backward Compatibility**: All existing functionality preserved

## Test Plan
- [ ] Verify existing field types still render correctly
- [ ] Test new checkbox field type with array data
- [ ] Confirm field validation and error display works
- [ ] Check helper text and placeholder functionality

🤖 Generated with [Claude Code](https://claude.ai/code)